### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,4 +1,6 @@
 name: Check
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/assets/security/code-scanning/3](https://github.com/Wbaker7702/assets/security/code-scanning/3)

To resolve the issue, you should add a minimal `permissions` block to restrict the GITHUB_TOKEN's access, either at the top level (applying to all jobs) or within the specific job. Since this workflow does not appear to need anything but the ability to read repository contents (for checkout and test/lint), set permissions to `contents: read`. The recommended place is at the top level, just below the workflow's name and before the `on:` or `jobs:` block. This approach is non-breaking and follows GitHub's least privilege principle.

Specifically, in `.github/workflows/check.yml`, add:

```yaml
permissions:
  contents: read
```

directly after the workflow's `name:` declaration and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated GitHub Actions workflow permissions to explicitly grant read access to repository contents.
  - Improves clarity and reliability of CI checks by defining required access at the workflow level.
  - No functional changes to application features or the workflow’s job/step behavior.
  - May affect what the checks can read during runs, ensuring they have the necessary access without elevating privileges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->