### PR TITLE
Fixing code bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,9 @@ build:
 
 test:
 	@echo "  >  Running unit tests"
-	go test -cover -race -coverprofile=coverage.txt -covermode=atomic -v ./...
+	# ensure artifacts don't pollute the repo root
+	mkdir -p bin
+	go test -cover -race -coverprofile=bin/coverage.txt -covermode=atomic -v ./...
 
 fmt:
 	@echo "  >  Format all go files"


### PR DESCRIPTION
Update Makefile to output `coverage.txt` to `bin/coverage.txt` to fix a failing repo check.

The `make check` command was failing because `coverage.txt` in the repository root was disallowed. This change moves the output to `bin/coverage.txt` to resolve the issue and prevent future pollution of the repo root.

---
<a href="https://cursor.com/background-agent?bcId=bc-0e03a973-cb8b-482b-9ed1-1344a3c8dab1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0e03a973-cb8b-482b-9ed1-1344a3c8dab1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build tooling configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->